### PR TITLE
Fix bug in iplc_sim_init and clean up iplc_sim_parse_reg

### DIFF
--- a/provided/iplc-sim.c
+++ b/provided/iplc-sim.c
@@ -147,7 +147,7 @@ void iplc_sim_init(int index, int blocksize, int assoc)
     
     cache_blockoffsetbits =
     (int) rint((log( (double) (blocksize * 4) )/ log(2)));
-    /* Note: rint function rounds the result up prior to casting */
+    /* Note: rint function rounds the result prior to casting */
     
     cache_size = assoc * ( 1 << index ) * ((32 * blocksize) + 33 - index - cache_blockoffsetbits);
     
@@ -163,7 +163,7 @@ void iplc_sim_init(int index, int blocksize, int assoc)
         exit(-1);
     }
     
-    cache = (cache_line_t *) malloc((sizeof(cache_line_t) * 1<<index));
+    cache = (cache_line_t *) malloc((sizeof(cache_line_t) * (1<<index)));
     
     // Dynamically create our cache based on the information the user entered
     for (i = 0; i < (1<<index); i++) {
@@ -371,6 +371,7 @@ void iplc_sim_process_pipeline_nop()
  */
 unsigned int iplc_sim_parse_reg(char *reg_str)
 {
+    /*
     int i;
     // turn comma into \n
     if (reg_str[strlen(reg_str)-1] == ',')
@@ -385,6 +386,10 @@ unsigned int iplc_sim_parse_reg(char *reg_str)
         
         return atoi(reg_str);
     }
+    */
+    
+    //equivalent to the above
+    return atoi(reg_str + (reg_str[0] == '$'));
 }
 
 /*


### PR DESCRIPTION
Don't know whether we should be modifying this file, but this fixes a subtle bug in the provided iplc_sim_init where the cache is allocated with the wrong size because there weren't parentheses where there should have been.

I also took the liberty of simplifying iplc_sim_parse_reg into something that runs in O(1) and doesn't crash on the empty string. It produced the same results as the original but doesn't modify the arguments.