### PR TITLE
Fix multi definition issue when compiling all files

### DIFF
--- a/src/base.c
+++ b/src/base.c
@@ -1,0 +1,25 @@
+#include "base.h"
+
+cache_line_t *cache=NULL;
+int cache_index=0;
+int cache_blocksize=0;
+int cache_blockoffsetbits = 0;
+int cache_assoc=0;
+long cache_miss=0;
+long cache_access=0;
+long cache_hit=0;
+
+char instruction[16];
+char reg1[16];
+char reg2[16];
+char offsetwithreg[16];
+unsigned int data_address=0;
+unsigned int instruction_address=0;
+unsigned int pipeline_cycles=0;   // how many cycles did you pipeline consume
+unsigned int instruction_count=0; // home many real instructions ran thru the pipeline
+unsigned int branch_predict_taken=0;
+unsigned int branch_count=0;
+unsigned int correct_branch_predictions=0;
+
+unsigned int debug=0;
+unsigned int dump_pipeline=1;

--- a/src/base.h
+++ b/src/base.h
@@ -23,29 +23,29 @@ typedef struct cache_line
     // a method for selecting which item in the cache is going to be replaced
 } cache_line_t;
 
-cache_line_t *cache=NULL;
-int cache_index=0;
-int cache_blocksize=0;
-int cache_blockoffsetbits = 0;
-int cache_assoc=0;
-long cache_miss=0;
-long cache_access=0;
-long cache_hit=0;
+cache_line_t *cache;
+int cache_index;
+int cache_blocksize;
+int cache_blockoffsetbits;
+int cache_assoc;
+long cache_miss;
+long cache_access;
+long cache_hit;
 
 char instruction[16];
 char reg1[16];
 char reg2[16];
 char offsetwithreg[16];
-unsigned int data_address=0;
-unsigned int instruction_address=0;
-unsigned int pipeline_cycles=0;   // how many cycles did you pipeline consume
-unsigned int instruction_count=0; // home many real instructions ran thru the pipeline
-unsigned int branch_predict_taken=0;
-unsigned int branch_count=0;
-unsigned int correct_branch_predictions=0;
+unsigned int data_address;
+unsigned int instruction_address;
+unsigned int pipeline_cycles;   // how many cycles did you pipeline consume
+unsigned int instruction_count; // home many real instructions ran thru the pipeline
+unsigned int branch_predict_taken;
+unsigned int branch_count;
+unsigned int correct_branch_predictions;
 
-unsigned int debug=0;
-unsigned int dump_pipeline=1;
+unsigned int debug;
+unsigned int dump_pipeline;
 
 enum instruction_type {NOP, RTYPE, LW, SW, BRANCH, JUMP, JAL, SYSCALL};
 


### PR DESCRIPTION
Fix multiple definition errors when running "gcc src/*.c"